### PR TITLE
fix go.mod module directive

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module nuitka-extractor
+module github.com/extremecoders-re/nuitka-extractor
 
 go 1.19
 


### PR DESCRIPTION
This allows to do `go install github.com/extremecoders-re/nuitka-extractor@latest`